### PR TITLE
(feat) Add API endpoints for annotation feature

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,6 +35,8 @@ app.delete("/api/users/urls", handle.urlRemove);
 app.post("/api/users/notes/", handle.userAddNotes);
 app.delete("/api/users/notes", handle.noteRemove);
 
+app.post('/api/users/notes/annotations/', handle.userAddAnnotations);
+
 var port = process.env.PORT || 3003;
 
 app.listen(port, () => {

--- a/server.js
+++ b/server.js
@@ -36,6 +36,7 @@ app.post("/api/users/notes/", handle.userAddNotes);
 app.delete("/api/users/notes", handle.noteRemove);
 
 app.post('/api/users/notes/annotations/', handle.userAddAnnotations);
+app.delete('/api/users/notes/annotations/', handle.annotationRemove);
 
 var port = process.env.PORT || 3003;
 

--- a/server/requestHandler.js
+++ b/server/requestHandler.js
@@ -138,3 +138,39 @@ exports.userAddNotes = function userAddNotes(req, res) {
     });
   }
 };
+
+exports.userAddAnnotations = function userAddAnnotations(req, res) {
+  //send name/uri/note/annotation in body
+  if (req.body.annotation === null || req.body.annotation === '') {
+    res.status(404).send('Please add an annotation.');
+  } else if (!req.body.user_id) {
+    res.status(404).send('Please log in.');
+  } else {
+    User.findOne({user_id: req.body.user_id}, (err, user) => {
+      if(err) {
+        res.status(404).send('Could not find user.');
+      }
+
+      var pages = user.urls.map(site => site.name);
+
+      if (pages.includes(req.body.uri)) {
+        var pins = user.urls[pages.indexOf(req.body.uri)].pins;
+        var note = pins.find(function(pin) {
+          return pin.text === req.body.note;
+        });
+
+        if (!note) {
+          res.status(404).send('Could not find note');
+          return;
+        }
+
+        note.annotation = req.body.annotation;
+        user.markModified('urls');
+        user.save();
+        res.status(201).send('Successfully added annotation: ' + req.body.annotation);
+      } else {
+        res.status(404).send('Could not find url');
+      }
+    });
+  }
+};

--- a/server/requestHandler.js
+++ b/server/requestHandler.js
@@ -120,16 +120,18 @@ exports.userAddNotes = function userAddNotes(req, res) {
 
       var pages = user.urls.map(site => site.name);
 
+      var pin = {
+        text: req.body.note,
+        color: req.body.color || 'yellow',
+        annotation: req.body.annotation || ''
+      };
+
       if(pages.includes(req.body.uri)) {
-        user.urls[pages.indexOf(req.body.uri)].pins.push({
-          text: req.body.note
-        });
+        user.urls[pages.indexOf(req.body.uri)].pins.push(pin);
       } else {
         user.urls.push({
           name: req.body.uri,
-          pins: [{
-            text: req.body.note
-          }],
+          pins: [pin],
         });
       }
       user.markModified('urls');


### PR DESCRIPTION
WIP on #5 

New API endpoints for adding and removing an annotation:
```
POST /api/users/notes/annotations/
DELETE /api/users/notes/annotations/
```

Also, if annotation or color is not available when adding a note, they will default to `''` and `'yellow'`, respectively.